### PR TITLE
Fix memory leak in spooledtempfile Close()

### DIFF
--- a/pkg/spooledtempfile/spooled.go
+++ b/pkg/spooledtempfile/spooled.go
@@ -254,10 +254,10 @@ func (s *spooledTempFile) Close() error {
 
 	// Release the buffer back to the pool
 	if s.buf != nil {
-		s.buf = nil
-		if s.buf != nil && cap(s.buf) <= InitialBufferSize && cap(s.buf) > 0 {
+		if cap(s.buf) <= InitialBufferSize && cap(s.buf) > 0 {
 			spooledPool.Put(s.buf[:0]) // Reset the buffer before returning it to the pool
 		}
+		s.buf = nil
 	}
 
 	if s.file == nil {


### PR DESCRIPTION
We don't release the memory correctly on close.
We set `s.buf = nil` and the `if` statement after that is never executed.
Also, we double check if `s.buf != nil`, we already checked that in the previous line.