### PR TITLE
Optimise spooledtempfile.getSystemMemoryUsedFraction

### DIFF
--- a/pkg/spooledtempfile/spooled.go
+++ b/pkg/spooledtempfile/spooled.go
@@ -341,6 +341,9 @@ var getSystemMemoryUsedFraction = func() (float64, error) {
 		case "Cached":
 			cached = value
 		}
+		if memTotal > 0 && memAvailable > 0 {
+			break
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return 0, fmt.Errorf("scanner error reading /proc/meminfo: %v", err)


### PR DESCRIPTION
There is no need to always read all /proc/meminfo lines. Stop reading as soon as we find the 2 variables that are necessary for the result.