### PR TITLE
Remove unused DNSServer var

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ type HTTPClientSettings struct {
 	RotatorSettings       *RotatorSettings
 	Proxy                 string
 	TempDir               string
-	DNSServer             string
 	DiscardHook           DiscardHook
 	DNSServers            []string
 	DedupeOptions         DedupeOptions

--- a/dialer.go
+++ b/dialer.go
@@ -31,7 +31,6 @@ type customDialer struct {
 	DNSClient   *dns.Client
 	DNSRecords  *otter.Cache[string, net.IP]
 	net.Dialer
-	DNSServer   string
 	disableIPv4 bool
 	disableIPv6 bool
 }


### PR DESCRIPTION
We have `DNSServers`, `DNSServer` must be a leftover from the past.