### PR TITLE
Remove unused TCPTimeout variable

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,7 +26,6 @@ type HTTPClientSettings struct {
 	DNSRecordsTTL         time.Duration
 	DNSCacheSize          int
 	TLSHandshakeTimeout   time.Duration
-	TCPTimeout            time.Duration
 	MaxReadBeforeTruncate int
 	DecompressBody        bool
 	FollowRedirects       bool
@@ -170,10 +169,6 @@ func NewWARCWritingHTTPClient(HTTPClientSettings HTTPClientSettings) (httpClient
 
 	if HTTPClientSettings.TLSHandshakeTimeout == 0 {
 		HTTPClientSettings.TLSHandshakeTimeout = 10 * time.Second
-	}
-
-	if HTTPClientSettings.TCPTimeout == 0 {
-		HTTPClientSettings.TCPTimeout = 10 * time.Second
 	}
 
 	if HTTPClientSettings.DNSResolutionTimeout == 0 {


### PR DESCRIPTION
The timeouts are configured via the dialer.
Go doesn't use a `TCPTimeout` var in the HTTP client. This must be a leftover variable.