### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 'go.mod'
+        go-version-file: 'go.mod'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23.5'
+        go-version: 'go.mod'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Potential fix for [https://github.com/internetarchive/gowarc/security/code-scanning/1](https://github.com/internetarchive/gowarc/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only involves building, testing, and benchmarking code, it does not require write permissions. The minimal permissions required are `contents: read`, which allows the workflow to access the repository's contents without granting write access. This change ensures that the workflow adheres to the principle of least privilege and reduces the risk of unintended modifications.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
