### PR TITLE
Add Accept-Encoding: gzip header to requests

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -50,7 +50,7 @@ func newCustomTransport(dialer *customDialer, decompressBody bool, TLSHandshakeT
 		TLSHandshakeTimeout:   TLSHandshakeTimeout,
 		ExpectContinueTimeout: 5 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-		DisableCompression:    true,
+		DisableCompression:    false,
 		ForceAttemptHTTP2:     false,
 		MaxIdleConns:          -1,
 		MaxIdleConnsPerHost:   -1,


### PR DESCRIPTION
This will give a big performance boost because the network traffic will be much smaller.

Accoding to https://pkg.go.dev/net/http

DisableCompression, if true, prevents the Transport from requesting compression with an "Accept-Encoding: gzip" request header when the Request contains no existing Accept-Encoding value. If the Transport requests gzip on its own and gets a gzipped response, it's transparently decoded in the Response.Body. However, if the user explicitly requested gzip it is not automatically uncompressed.

So, no other changes should be necessary. Decompression should happen transparently.