### PR TITLE
FIX various bugs related to HTTP connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,6 +26,7 @@ type HTTPClientSettings struct {
 	DNSRecordsTTL         time.Duration
 	DNSCacheSize          int
 	TLSHandshakeTimeout   time.Duration
+	ConnReadDeadline      time.Duration
 	MaxReadBeforeTruncate int
 	DecompressBody        bool
 	FollowRedirects       bool
@@ -51,6 +52,7 @@ type CustomHTTPClient struct {
 	DiscardHook            DiscardHook
 	dedupeOptions          DedupeOptions
 	TLSHandshakeTimeout    time.Duration
+	ConnReadDeadline       time.Duration
 	MaxReadBeforeTruncate  int
 	verifyCerts            bool
 	FullOnDisk             bool
@@ -204,6 +206,7 @@ func NewWARCWritingHTTPClient(HTTPClientSettings HTTPClientSettings) (httpClient
 	}
 
 	httpClient.TLSHandshakeTimeout = HTTPClientSettings.TLSHandshakeTimeout
+	httpClient.ConnReadDeadline = HTTPClientSettings.ConnReadDeadline
 
 	// Configure custom dialer / transport
 	customDialer, err := newCustomDialer(httpClient, HTTPClientSettings.Proxy, HTTPClientSettings.DialTimeout, HTTPClientSettings.DNSRecordsTTL, HTTPClientSettings.DNSResolutionTimeout, HTTPClientSettings.DNSCacheSize, HTTPClientSettings.DNSServers, HTTPClientSettings.DisableIPv4, HTTPClientSettings.DisableIPv6)

--- a/dialer.go
+++ b/dialer.go
@@ -513,7 +513,7 @@ func (d *customDialer) readResponse(ctx context.Context, respPipe *io.PipeReader
 	// Calculate the WARC-Payload-Digest
 	payloadDigest := GetSHA1(resp.Body)
 	if strings.HasPrefix(payloadDigest, "ERROR: ") {
-		// This should happen if the connection was closed halfway through reading the response body
+		// This should _never_ happen.
 		return fmt.Errorf("readResponse: SHA1 ran into an unrecoverable error: %s url: %s", payloadDigest, warcTargetURI)
 	}
 

--- a/dialer.go
+++ b/dialer.go
@@ -133,6 +133,14 @@ func (d *customDialer) wrapConnection(ctx context.Context, c net.Conn, scheme st
 		Reader:  io.TeeReader(c, respWriter),
 		Writer:  io.MultiWriter(reqWriter, c),
 	}
+	if ctx.Value("wrappedConn") != nil {
+		connChan, ok := ctx.Value("wrappedConn").(chan *CustomConnection)
+		if !ok {
+			panic("wrapConnection: wrappedConn channel is not of type chan *CustomConnection")
+		}
+		connChan <- wrappedConn
+		close(connChan)
+	}
 	return wrappedConn
 }
 


### PR DESCRIPTION
## Bug 1: `readResponse()` will get normal EOF instead of getting an error if there is a connection error.

1.1:

![image](https://github.com/user-attachments/assets/d20b1abe-8eb3-4540-9cd3-d8ee62261f36)

We should use the `io.PipeWriter.CloseWithError()` instead of normal `io.PipeWriter.Close()` to close connection, otherwise our warpped `io.PipeReader` (reqReader, respReader) will not get any non EOF errors on `Read()`.


1.2: `http` library mitigates this bug for us

![image](https://github.com/user-attachments/assets/b89c6331-7280-4e3c-b541-b1e9bff87d56)

![image](https://github.com/user-attachments/assets/2776335e-05d4-4163-b4f6-27ea55d970d2)

When `http.ReadRespon()` assembles `resp.Body`, if `Content-Length` exists, its value will be used to construct `resp.Body: io.LimitReader`. 2️⃣
So, the constructed LimitReader is able to detect and return abnormal early EOF for response where the `Content-Length` header is present. 3️⃣

~~Thanks to the http standard library, it saved our lives for most responses!~~

---

This is why https://github.com/internetarchive/Zeno/pull/369 streaming response payload was not discarded and got recorded.

Solution:

When `*CustomConnection.Read()` fails, call `CloseWithError()` to synchronously feedback the error to `io.PipeWriter`. In this way, `io.PipeReader` (reqReader, respReader) in the `writeWARCFromConnection` coroutine can also receive the connection error instead of silent EOF.

## Bug 2: `--http-read-deadline` has no effect.

The current `resp.Body` does not have the `SetReadDeadline()` interface.

![image](https://github.com/user-attachments/assets/9973664f-fa2b-4a1a-9dca-8ecf39e4e43c)

https://github.com/internetarchive/Zeno/blob/50316669eefebc743916ead69e79c86ec04970a2/internal/pkg/archiver/body.go#L20-L27

So `--http-read-deadline` NEVER take effect.

To make `.SetReadDeadline()` work properly, I added a new `ConnReadDeadline` option, which calls `.SetReadDeadline()` on every `*CustomConnection.Read()`

## Bug 3: There is a chance that req&resp temporary on-disk records may not be closed (deleted) when an error occurs.

![image](https://github.com/user-attachments/assets/467bc09c-50ac-4e83-838c-39e8ef223d53)

![image](https://github.com/user-attachments/assets/4518309e-adee-4dc1-953f-f3c5795033c5)

![image](https://github.com/user-attachments/assets/d73ea533-9d9f-4402-8585-93840470b491)

![image](https://github.com/user-attachments/assets/b1f480e6-11d1-48e7-af2c-f77cdfc5fb46)

In `readRequest()` and `readResponse()`, we didn't send *record to the `recordChan` until the end of the function. During the process, we didn't take care to close `*record.Content` after each error. This resulted in these failed records remaining in ./jobs/{job}/temp .

Solution:
Pass `*record` to `recordChan` ASAP.

![image](https://github.com/user-attachments/assets/e0a8dda4-a85a-45d3-8d14-daad892c2e1a)

This way we can ensure that on error, all created records will be closed.

## Feature 1: Expose the `*CustomConnection` to the upper layer

To allows Zeno to actively close the connection after reading more than `--max-content-length`. (https://github.com/internetarchive/Zeno/pull/369) We need to pass the warclib's `*CustomConnection` to the Zeno, so I added `wrappedConnChan`.
