### PR TITLE
`ReadRecord()` accept opts to modulate output

### DIFF
--- a/read.go
+++ b/read.go
@@ -74,7 +74,6 @@ func (r *Reader) ReadRecord(opts ...ReadOpts) (*Record, bool, error) {
 	for _, opt := range opts {
 		switch opt {
 		case ReadOptsNoContentOutput:
-			fmt.Println("ReadOptsNoContentOutput enabled, discarding content")
 			discardContent = true
 		}
 	}

--- a/read.go
+++ b/read.go
@@ -147,9 +147,11 @@ func (r *Reader) ReadRecord(opts ...ReadOpts) (*Record, bool, error) {
 	return r.record, false, nil // ok
 }
 
+// ReadOpts are options for ReadRecord
 type ReadOpts int
 
 const (
-	ReadOptsNone ReadOpts = iota
-	ReadOptsNoContentOutput
+	// ReadOptsNoContentOutput means that the content of the record should not be returned.
+	// This is useful for reading only the headers or metadata of the record.
+	ReadOptsNoContentOutput ReadOpts = iota
 )

--- a/read.go
+++ b/read.go
@@ -64,11 +64,20 @@ func readUntilDelim(r reader, delim []byte) (line []byte, err error) {
 //   - Record: if an error occurred, record **may be** nil. if eol is true, record **must be** nil.
 //   - bool (eol): if true, we readed all records successfully.
 //   - error: error
-func (r *Reader) ReadRecord() (*Record, bool, error) {
+func (r *Reader) ReadRecord(opts ...ReadOpts) (*Record, bool, error) {
 	var (
-		err        error
-		tempReader *bufio.Reader
+		err            error
+		tempReader     *bufio.Reader
+		discardContent bool
 	)
+
+	for _, opt := range opts {
+		switch opt {
+		case ReadOptsNoContentOutput:
+			fmt.Println("ReadOptsNoContentOutput enabled, discarding content")
+			discardContent = true
+		}
+	}
 
 	tempReader = bufio.NewReader(r.bufReader)
 
@@ -105,7 +114,11 @@ func (r *Reader) ReadRecord() (*Record, bool, error) {
 
 	// reading doesn't really need to be in TempDir, nor can we access it as it's on the client.
 	buf := spooledtempfile.NewSpooledTempFile("warc", "", r.threshold, false, -1)
-	_, err = io.CopyN(buf, tempReader, length)
+	if discardContent {
+		_, err = io.CopyN(io.Discard, tempReader, length)
+	} else {
+		_, err = io.CopyN(buf, tempReader, length)
+	}
 	if err != nil {
 		return nil, false, fmt.Errorf("copying record content: %w", err)
 	}
@@ -134,3 +147,10 @@ func (r *Reader) ReadRecord() (*Record, bool, error) {
 
 	return r.record, false, nil // ok
 }
+
+type ReadOpts int
+
+const (
+	ReadOptsNone ReadOpts = iota
+	ReadOptsNoContentOutput
+)

--- a/read_test.go
+++ b/read_test.go
@@ -340,6 +340,39 @@ func TestReader(t *testing.T) {
 	}
 }
 
+func TestReaderNoContentOpt(t *testing.T) {
+	var paths = []string{
+		"testdata/test.warc.gz",
+	}
+	for _, path := range paths {
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("failed to open %q: %v", path, err)
+		}
+		defer file.Close()
+
+		reader, err := NewReader(file)
+		if err != nil {
+			t.Fatalf("warc.NewReader failed for %q: %v", path, err)
+		}
+
+		for {
+			record, eol, err := reader.ReadRecord(ReadOptsNoContentOutput)
+			if eol {
+				break
+			}
+			if err != nil {
+				t.Fatalf("failed to read all record content: %v", err)
+				break
+			}
+
+			if record.Content.Len() > 0 {
+				t.Fatal("expected no content, got content")
+			}
+		}
+	}
+}
+
 func BenchmarkBasicRead(b *testing.B) {
 	// default test warc location
 	path := "testdata/test.warc.gz"


### PR DESCRIPTION
That and adding a `ReadOptsNoContentOutput` to avoid passing the WARC record content block if it's not needed by the caller