### PR TITLE
Remove hypenated formatting from set of accepted digest algorithms

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -26,7 +26,7 @@ var ErrUnknownDigestAlgorithm = errors.New("unknown digest algorithm")
 
 func IsDigestSupported(algorithm string) bool {
 	switch algorithm {
-	case "sha1", "sha-1", "sha256", "sha-256", "blake3":
+	case "sha1", "sha256", "blake3":
 		return true
 	default:
 		return false

--- a/digest.go
+++ b/digest.go
@@ -35,9 +35,9 @@ func IsDigestSupported(algorithm string) bool {
 
 func GetDigestFromPrefix(prefix string) DigestAlgorithm {
 	switch prefix {
-	case "sha1", "sha-1":
+	case "sha1":
 		return SHA1
-	case "sha256", "sha-256":
+	case "sha256":
 		return SHA256Base16
 	case "blake3":
 		return BLAKE3


### PR DESCRIPTION
Closes #131 

I'm on the fence about whether this fix is necessary, but I have concerns that someone might enter `sha-1` into the runtime argument for selecting a hash algorithm and expect the WARC digest to read back `sha-1`, even though it will always be written to the field as `sha1`. Since this is a new flag, I don't think we need to build in the option for someone to learn a bad habit.

Thoughts?