### PR TITLE
Add cgroups support in spooledtempfile (+ benchmarks)

### DIFF
--- a/pkg/spooledtempfile/memory_test.go
+++ b/pkg/spooledtempfile/memory_test.go
@@ -1,0 +1,362 @@
+package spooledtempfile
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// --- helpers ---
+
+type savedPaths struct {
+	v2Usage, v2High, v2Max string
+	v1Usage, v1Limit       string
+	meminfo                string
+}
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func saveAndRedirectPaths(t *testing.T, base string) (restore func()) {
+	t.Helper()
+
+	old := savedPaths{
+		v2Usage: cgv2UsagePath, v2High: cgv2HighPath, v2Max: cgv2MaxPath,
+		v1Usage: cgv1UsagePath, v1Limit: cgv1LimitPath,
+		meminfo: procMeminfoPath,
+	}
+
+	// Point to files under base; tests will create only what they need.
+	cgv2UsagePath = filepath.Join(base, "sys/fs/cgroup/memory.current")
+	cgv2HighPath = filepath.Join(base, "sys/fs/cgroup/memory.high")
+	cgv2MaxPath = filepath.Join(base, "sys/fs/cgroup/memory.max")
+	cgv1UsagePath = filepath.Join(base, "sys/fs/cgroup/memory/memory.usage_in_bytes")
+	cgv1LimitPath = filepath.Join(base, "sys/fs/cgroup/memory/memory.limit_in_bytes")
+	procMeminfoPath = filepath.Join(base, "proc/meminfo")
+
+	return func() {
+		cgv2UsagePath, cgv2HighPath, cgv2MaxPath = old.v2Usage, old.v2High, old.v2Max
+		cgv1UsagePath, cgv1LimitPath = old.v1Usage, old.v1Limit
+		procMeminfoPath = old.meminfo
+	}
+}
+
+// --- cgroup v2 ---
+
+func TestCgroupV2_UsesHighWhenStricterThanMax(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	// usage=400
+	writeFile(t, dir, "sys/fs/cgroup/memory.current", "400")
+	// high=800, max=1000 -> use high, frac = 0.5
+	writeFile(t, dir, "sys/fs/cgroup/memory.high", "800")
+	writeFile(t, dir, "sys/fs/cgroup/memory.max", "1000")
+
+	frac, ok, err := cgroupV2UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if got, want := frac, 0.5; got != want {
+		t.Fatalf("frac=%v want=%v", got, want)
+	}
+}
+
+func TestCgroupV2_FallbackToMaxWhenHighIsMax(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	writeFile(t, dir, "sys/fs/cgroup/memory.current", "300")
+	writeFile(t, dir, "sys/fs/cgroup/memory.high", "max") // unset
+	writeFile(t, dir, "sys/fs/cgroup/memory.max", "600")  // use this
+
+	frac, ok, err := cgroupV2UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if got, want := frac, 0.5; got != want {
+		t.Fatalf("frac=%v want=%v", got, want)
+	}
+}
+
+func TestCgroupV2_FallbackToMaxWhenHighInvalid(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	writeFile(t, dir, "sys/fs/cgroup/memory.current", "256")
+	writeFile(t, dir, "sys/fs/cgroup/memory.high", "not-a-number")
+	writeFile(t, dir, "sys/fs/cgroup/memory.max", "512")
+
+	frac, ok, err := cgroupV2UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if got, want := frac, 0.5; got != want {
+		t.Fatalf("frac=%v want=%v", got, want)
+	}
+}
+
+func TestCgroupV2_UseMaxWhenHighGTE_Max(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	writeFile(t, dir, "sys/fs/cgroup/memory.current", "900")
+	writeFile(t, dir, "sys/fs/cgroup/memory.high", "1000") // >= max
+	writeFile(t, dir, "sys/fs/cgroup/memory.max", "1000")
+
+	frac, ok, err := cgroupV2UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if got, want := frac, 0.9; got != want {
+		t.Fatalf("frac=%v want=%v", got, want)
+	}
+}
+
+func TestCgroupV2_OnlyHighSet(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	writeFile(t, dir, "sys/fs/cgroup/memory.current", "50")
+	writeFile(t, dir, "sys/fs/cgroup/memory.high", "100")
+	// no max file
+
+	frac, ok, err := cgroupV2UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if got, want := frac, 0.5; got != want {
+		t.Fatalf("frac=%v want=%v", got, want)
+	}
+}
+
+func TestCgroupV2_NoLimitsOrUsageFile(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	// usage missing -> ok=false (not cgroup v2 / not accessible)
+	_, ok, err := cgroupV2UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when usage missing")
+	}
+
+	// Now create usage but high=max and no max => no effective limit
+	writeFile(t, dir, "sys/fs/cgroup/memory.current", "123")
+	writeFile(t, dir, "sys/fs/cgroup/memory.high", "max")
+	frac, ok, err := cgroupV2UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false with no effective limit, got ok and frac=%v", frac)
+	}
+}
+
+// --- cgroup v1 ---
+
+func TestCgroupV1_NormalFraction(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	writeFile(t, dir, "sys/fs/cgroup/memory/memory.usage_in_bytes", "200")
+	writeFile(t, dir, "sys/fs/cgroup/memory/memory.limit_in_bytes", "400")
+
+	frac, ok, err := cgroupV1UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if got, want := frac, 0.5; got != want {
+		t.Fatalf("frac=%v want=%v", got, want)
+	}
+}
+
+func TestCgroupV1_HugeLimitMeansNoLimit(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	writeFile(t, dir, "sys/fs/cgroup/memory/memory.usage_in_bytes", "42")
+	// > 1<<60
+	writeFile(t, dir, "sys/fs/cgroup/memory/memory.limit_in_bytes", strconv.FormatUint((1<<60)+1, 10))
+
+	_, ok, err := cgroupV1UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false for huge limit (no limit)")
+	}
+}
+
+func TestCgroupV1_MissingFilesOrZeroLimit(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	// Only usage present -> not ok
+	writeFile(t, dir, "sys/fs/cgroup/memory/memory.usage_in_bytes", "7")
+	_, ok, err := cgroupV1UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when limit missing")
+	}
+
+	// Now add zero limit -> not ok
+	writeFile(t, dir, "sys/fs/cgroup/memory/memory.limit_in_bytes", "0")
+	_, ok, err = cgroupV1UsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false for zero limit")
+	}
+}
+
+// --- /proc/meminfo fallback ---
+
+func TestHostMeminfo_UsesMemAvailableWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	// MemTotal and MemAvailable are in kB
+	meminfo := strings.Join([]string{
+		"MemTotal:       1000000 kB",
+		"MemAvailable:    250000 kB",
+		"Buffers:          10000 kB",
+		"Cached:           20000 kB",
+		"MemFree:          50000 kB",
+	}, "\n")
+	writeFile(t, dir, "proc/meminfo", meminfo)
+
+	frac, err := hostMeminfoUsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// used = total - available = 1000000 - 250000 = 750000 => 0.75
+	if got, want := frac, 0.75; got != want {
+		t.Fatalf("frac=%v want=%v", got, want)
+	}
+}
+
+func TestHostMeminfo_FallbackWithoutMemAvailable(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	meminfo := strings.Join([]string{
+		"MemTotal:  1000000 kB",
+		"MemFree:     100000 kB",
+		"Buffers:      50000 kB",
+		"Cached:      150000 kB",
+	}, "\n")
+	writeFile(t, dir, "proc/meminfo", meminfo)
+
+	frac, err := hostMeminfoUsedFraction()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// approxAvailable = 100000 + 50000 + 150000 = 300000
+	// used = 1000000 - 300000 = 700000 => 0.7
+	if got, want := frac, 0.7; got != want {
+		t.Fatalf("frac=%v want=%v", got, want)
+	}
+}
+
+func TestHostMeminfo_Errors(t *testing.T) {
+	dir := t.TempDir()
+	restore := saveAndRedirectPaths(t, dir)
+	defer restore()
+
+	// Missing file
+	if _, err := hostMeminfoUsedFraction(); err == nil {
+		t.Fatalf("expected error when /proc/meminfo missing")
+	}
+
+	// Present but missing MemTotal
+	writeFile(t, dir, "proc/meminfo", "MemFree: 1 kB\n")
+	if _, err := hostMeminfoUsedFraction(); err == nil {
+		t.Fatalf("expected error when MemTotal missing")
+	}
+}
+
+// --- read helpers ---
+
+func TestReadUint64FileIfExists(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing -> ok=false, err=nil
+	if _, ok, err := readUint64FileIfExists(filepath.Join(dir, "nope")); err != nil || ok {
+		t.Fatalf("expected ok=false, err=nil for missing file; got ok=%v err=%v", ok, err)
+	}
+
+	// Present & valid
+	p := writeFile(t, dir, "n.txt", "123\n")
+	v, ok, err := readUint64FileIfExists(p)
+	if err != nil || !ok || v != 123 {
+		t.Fatalf("got v=%d ok=%v err=%v; want 123,true,nil", v, ok, err)
+	}
+
+	// Present & invalid -> ok=false, err=nil
+	p = writeFile(t, dir, "bad.txt", "not-a-number")
+	if _, ok, err := readUint64FileIfExists(p); err != nil || ok {
+		t.Fatalf("expected ok=false, err=nil for invalid number; got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestReadStringFileIfExists(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, ok, err := readStringFileIfExists(filepath.Join(dir, "nope")); err != nil || ok {
+		t.Fatalf("expected ok=false, err=nil for missing file; got ok=%v err=%v", ok, err)
+	}
+
+	p := writeFile(t, dir, "s.txt", " hello \n")
+	s, ok, err := readStringFileIfExists(p)
+	if err != nil || !ok || strings.TrimSpace(s) != "hello" {
+		t.Fatalf("got s=%q ok=%v err=%v; want 'hello',true,nil", s, ok, err)
+	}
+}

--- a/pkg/spooledtempfile/spooled_bench_test.go
+++ b/pkg/spooledtempfile/spooled_bench_test.go
@@ -1,0 +1,303 @@
+package spooledtempfile
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func BenchmarkWrite_InMemory_Small(b *testing.B) {
+	// 256 KiB total, threshold 1 MiB => stays in memory
+	const total = 256 << 10
+	const chunk = 32 << 10
+	data := randBytes(chunk)
+	tempDir := makeTempDir(&testing.T{})
+
+	b.ReportAllocs()
+	b.SetBytes(total)
+	for b.Loop() {
+		s := NewSpooledTempFile("bench", tempDir, 1<<20, false, DefaultMaxRAMUsageFraction)
+		repeatWrite(b, s, total, chunk, data)
+		if err := s.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWrite_SpillToDisk(b *testing.B) {
+	// 4 MiB total, threshold 1 MiB => will spill
+	const total = 4 << 20
+	const chunk = 128 << 10
+	data := randBytes(chunk)
+	tempDir := makeTempDir(&testing.T{})
+
+	b.ReportAllocs()
+	b.SetBytes(total)
+	for b.Loop() {
+		s := NewSpooledTempFile("bench", tempDir, 1<<20, false, DefaultMaxRAMUsageFraction)
+		repeatWrite(b, s, total, chunk, data)
+		if err := s.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWrite_FullOnDisk(b *testing.B) {
+	// 4 MiB total, fullOnDisk=true => always file
+	const total = 4 << 20
+	const chunk = 128 << 10
+	data := randBytes(chunk)
+	tempDir := makeTempDir(&testing.T{})
+
+	b.ReportAllocs()
+	b.SetBytes(total)
+	for b.Loop() {
+		s := NewSpooledTempFile("bench", tempDir, 1<<20, true, DefaultMaxRAMUsageFraction)
+		repeatWrite(b, s, total, chunk, data)
+		if err := s.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWrite_SpillDueToHighMemSignal(b *testing.B) {
+	// Simulate high system memory usage to force disk path, even below threshold
+	const total = 256 << 10
+	const chunk = 32 << 10
+	data := randBytes(chunk)
+	tempDir := makeTempDir(&testing.T{})
+
+	orig := getSystemMemoryUsedFraction
+	getSystemMemoryUsedFraction = func() (float64, error) { return 0.99, nil }
+	defer func() { getSystemMemoryUsedFraction = orig }()
+
+	b.ReportAllocs()
+	b.SetBytes(total)
+	for b.Loop() {
+		s := NewSpooledTempFile("bench", tempDir, 1<<20, false, 0.50)
+		repeatWrite(b, s, total, chunk, data)
+		if err := s.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRead_AfterWrite_InMemory(b *testing.B) {
+	// Prepare an in-memory object then benchmark full read
+	const total = 256 << 10
+	const chunk = 32 << 10
+	data := randBytes(chunk)
+	tempDir := makeTempDir(&testing.T{})
+
+	s := NewSpooledTempFile("bench", tempDir, 1<<20, false, DefaultMaxRAMUsageFraction)
+	repeatWrite(b, s, total, chunk, data)
+
+	// seal writing; first Read triggers in-memory reader
+	buf := make([]byte, 64<<10)
+	b.ReportAllocs()
+	b.SetBytes(int64(total))
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := s.Seek(0, io.SeekStart); err != nil {
+			b.Fatal(err)
+		}
+		read := 0
+		for {
+			n, err := s.Read(buf)
+			if n > 0 {
+				read += n
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.StopTimer()
+	if err := s.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkRead_AfterWrite_OnDisk(b *testing.B) {
+	// Prepare an on-disk object then benchmark full read
+	const total = 8 << 20
+	const chunk = 128 << 10
+	data := randBytes(chunk)
+	tempDir := makeTempDir(&testing.T{})
+
+	s := NewSpooledTempFile("bench", tempDir, 1<<20, false, DefaultMaxRAMUsageFraction)
+	repeatWrite(b, s, total, chunk, data)
+
+	buf := make([]byte, 128<<10)
+	b.ReportAllocs()
+	b.SetBytes(int64(total))
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := s.Seek(0, io.SeekStart); err != nil {
+			b.Fatal(err)
+		}
+		read := 0
+		for {
+			n, err := s.Read(buf)
+			if n > 0 {
+				read += n
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.StopTimer()
+	if err := s.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkReadAt_OnDisk(b *testing.B) {
+	// Prepare on-disk and then exercise ReadAt in random-ish blocks
+	const total = 16 << 20
+	const block = 64 << 10
+	tempDir := makeTempDir(&testing.T{})
+	payload := bytes.Repeat([]byte{0xAB}, 256<<10)
+
+	s := NewSpooledTempFile("bench", tempDir, 1<<20, false, DefaultMaxRAMUsageFraction)
+	repeatWrite(b, s, total, len(payload), payload)
+
+	buf := make([]byte, block)
+	b.ReportAllocs()
+	b.SetBytes(block)
+	b.ResetTimer()
+	pos := int64(0)
+	for b.Loop() {
+		if pos >= total-int64(block) {
+			pos = 0
+		}
+		if _, err := s.ReadAt(buf, pos); err != nil && err != io.EOF {
+			b.Fatal(err)
+		}
+		pos += int64(block)
+	}
+	b.StopTimer()
+	if err := s.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkParallel_CreateAndWrite_512KB(b *testing.B) {
+	// Measures throughput when many goroutines create/write their own instances.
+	const total = 512 << 10
+	const chunk = 32 << 10
+	data := randBytes(chunk)
+	tempDir := makeTempDir(&testing.T{})
+
+	b.ReportAllocs()
+	b.SetBytes(total)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			s := NewSpooledTempFile("bench", tempDir, 1<<20, false, DefaultMaxRAMUsageFraction)
+			repeatWrite(b, s, total, chunk, data)
+			if err := s.Close(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// Optional: end-to-end hash read to ensure we're not optimizing away I/O in benches.
+func BenchmarkRead_Hash_OnDisk(b *testing.B) {
+	const total = 32 << 20
+	const chunk = 256 << 10
+	data := randBytes(chunk)
+	tempDir := makeTempDir(&testing.T{})
+
+	s := NewSpooledTempFile("bench", tempDir, 1<<20, false, DefaultMaxRAMUsageFraction)
+	repeatWrite(b, s, total, chunk, data)
+
+	buf := make([]byte, 256<<10)
+	b.ReportAllocs()
+	b.SetBytes(int64(total))
+	b.ResetTimer()
+	for b.Loop() {
+		h := sha256.New()
+		if _, err := s.Seek(0, io.SeekStart); err != nil {
+			b.Fatal(err)
+		}
+		for {
+			n, err := s.Read(buf)
+			if n > 0 {
+				_, _ = h.Write(buf[:n])
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = h.Sum(nil)
+	}
+	b.StopTimer()
+	if err := s.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+// (Optional) micro-benchmark of create+close cost (no writes).
+func BenchmarkCreateClose_NoWrite(b *testing.B) {
+	tempDir := makeTempDir(&testing.T{})
+	b.ReportAllocs()
+	for b.Loop() {
+		s := NewSpooledTempFile("bench", tempDir, 1<<20, false, DefaultMaxRAMUsageFraction)
+		if err := s.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Guard to avoid unused import complaints in case some paths compile out.
+var _ = time.Now
+var _ = os.ErrNotExist
+
+func randBytes(n int) []byte {
+	// Deterministic for stable benches
+	r := rand.New(rand.NewSource(42))
+	b := make([]byte, n)
+	_, _ = r.Read(b)
+	return b
+}
+
+func repeatWrite(t *testing.B, w io.Writer, total, chunk int, payload []byte) {
+	written := 0
+	for written < total {
+		to := chunk
+		if written+to > total {
+			to = total - written
+		}
+		if _, err := w.Write(payload[:to]); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		written += to
+	}
+}
+
+func makeTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	// Ensure absolute
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}

--- a/pkg/spooledtempfile/spooled_memory.go
+++ b/pkg/spooledtempfile/spooled_memory.go
@@ -1,0 +1,170 @@
+package spooledtempfile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// getSystemMemoryUsedFraction returns used/limit for the container if
+// cgroup limits are set; otherwise falls back to host /proc/meminfo.
+var getSystemMemoryUsedFraction = func() (float64, error) {
+	// 1) Try cgroup v2 (unified hierarchy)
+	if frac, ok, err := cgroupV2UsedFraction(); err != nil {
+		return 0, err
+	} else if ok {
+		return frac, nil
+	}
+
+	// 2) Try cgroup v1 (legacy)
+	if frac, ok, err := cgroupV1UsedFraction(); err != nil {
+		return 0, err
+	} else if ok {
+		return frac, nil
+	}
+
+	// 3) Fallback to host view
+	return hostMeminfoUsedFraction()
+}
+
+func cgroupV2UsedFraction() (frac float64, ok bool, err error) {
+	// Common modern path with systemd/docker/containerd/Nomad on cgroup v2
+	const (
+		usagePath = "/sys/fs/cgroup/memory.current"
+		limitPath = "/sys/fs/cgroup/memory.max"
+	)
+
+	usage, uok, err := readUint64FileIfExists(usagePath)
+	if err != nil {
+		return 0, false, err
+	}
+
+	limitStr, lok, err := readStringFileIfExists(limitPath)
+	if err != nil {
+		return 0, false, err
+	}
+	if !uok || !lok {
+		return 0, false, nil // not v2 (or not accessible)
+	}
+
+	limitStr = strings.TrimSpace(limitStr)
+	if limitStr == "max" || limitStr == "" {
+		// No effective limit -> not useful for container fraction
+		return 0, false, nil
+	}
+
+	limit, err := strconv.ParseUint(limitStr, 10, 64)
+	if err != nil || limit == 0 {
+		return 0, false, nil
+	}
+
+	return float64(usage) / float64(limit), true, nil
+}
+
+func cgroupV1UsedFraction() (frac float64, ok bool, err error) {
+	const (
+		usagePath = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+		limitPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	)
+
+	usage, uok, err := readUint64FileIfExists(usagePath)
+	if err != nil {
+		return 0, false, err
+	}
+
+	limit, lok, err := readUint64FileIfExists(limitPath)
+	if err != nil {
+		return 0, false, err
+	}
+	if !uok || !lok || limit == 0 {
+		return 0, false, nil
+	}
+
+	// Some kernels report a huge limit (e.g., ~max uint64) to mean "no limit"
+	if limit > (1 << 60) { // heuristic ~ 1 exabyte
+		return 0, false, nil
+	}
+
+	return float64(usage) / float64(limit), true, nil
+}
+
+func hostMeminfoUsedFraction() (float64, error) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, fmt.Errorf("failed to open /proc/meminfo: %v", err)
+	}
+	defer f.Close()
+
+	var memTotal, memAvailable, memFree, buffers, cached uint64
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimRight(fields[0], ":")
+		val, _ := strconv.ParseUint(fields[1], 10, 64) // kB
+		switch key {
+		case "MemTotal":
+			memTotal = val
+		case "MemAvailable":
+			memAvailable = val
+		case "MemFree":
+			memFree = val
+		case "Buffers":
+			buffers = val
+		case "Cached":
+			cached = val
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return 0, fmt.Errorf("scanner error reading /proc/meminfo: %v", err)
+	}
+	if memTotal == 0 {
+		return 0, fmt.Errorf("could not find MemTotal in /proc/meminfo")
+	}
+
+	var used uint64
+	if memAvailable > 0 {
+		used = memTotal - memAvailable
+	} else {
+		approxAvailable := memFree + buffers + cached
+		used = memTotal - approxAvailable
+	}
+
+	// meminfo is in kB; unit cancels in the fraction
+	return float64(used) / float64(memTotal), nil
+}
+
+func readUint64FileIfExists(path string) (val uint64, ok bool, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+
+	// v2 may use "max"; caller handles that as not-ok
+	v, perr := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if perr != nil {
+		return 0, false, nil
+	}
+
+	return v, true, nil
+}
+
+func readStringFileIfExists(path string) (string, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	return string(data), true, nil
+}

--- a/pkg/spooledtempfile/spooled_test.go
+++ b/pkg/spooledtempfile/spooled_test.go
@@ -503,7 +503,7 @@ func TestPoolBehavior(t *testing.T) {
 	}
 
 	// Retrieve a buffer from the pool
-	buf := spooledPool.Get().([]byte)
+	buf := getPooledBuf()
 
 	// Verify that the retrieved buffer has the expected initial capacity
 	if cap(buf) != InitialBufferSize {
@@ -559,7 +559,7 @@ func TestBufferGrowthBeyondNewCap(t *testing.T) {
 	}
 
 	// Verify that the buffer was released to the pool (if it meets the criteria)
-	buf := spooledPool.Get().([]byte)
+	buf := getPooledBuf()
 	if cap(buf) != InitialBufferSize {
 		t.Errorf("Expected buffer in pool to have capacity %d, got %d", InitialBufferSize, cap(buf))
 	}


### PR DESCRIPTION
This pull request refactors the memory management logic in the `spooledtempfile` package to improve buffer pooling and system memory usage detection, and adds a comprehensive benchmark suite. The most significant changes include extracting and enhancing system memory usage detection **(with container/cgroup awareness)**, improving buffer pool safety and clarity, and introducing benchmarks to measure performance across various scenarios.

**Memory usage detection improvements:**

* Moved and refactored the system memory usage detection logic into a new file, `spooled_memory.go`, with support for cgroup v2, cgroup v1, and host memory detection, making the code container-aware and more robust. (`pkg/spooledtempfile/spooled_memory.go`, `pkg/spooledtempfile/spooled.go`) [[1]](diffhunk://#diff-4f5e4c23a002e9b68ffd0eb0b3bef81a5a70a771a52c2a526a78ecdf6663dfdaR1-R170) [[2]](diffhunk://#diff-a6af32bdadc35f74d527b75e16648c3933f075502488ddc0043a2dcded446cc4L312-L363)

**Buffer pool management improvements:**

* Changed the buffer pool to store pointers to byte slices, added `getPooledBuf` and `putPooledBuf` helpers for safer and clearer buffer management, and updated all usages to use these helpers instead of direct pool access. (`pkg/spooledtempfile/spooled.go`) [[1]](diffhunk://#diff-a6af32bdadc35f74d527b75e16648c3933f075502488ddc0043a2dcded446cc4L36-R55) [[2]](diffhunk://#diff-a6af32bdadc35f74d527b75e16648c3933f075502488ddc0043a2dcded446cc4L106-R120) [[3]](diffhunk://#diff-a6af32bdadc35f74d527b75e16648c3933f075502488ddc0043a2dcded446cc4L210-R224) [[4]](diffhunk://#diff-a6af32bdadc35f74d527b75e16648c3933f075502488ddc0043a2dcded446cc4L227-R249) [[5]](diffhunk://#diff-a6af32bdadc35f74d527b75e16648c3933f075502488ddc0043a2dcded446cc4L256-R267)
* Updated tests to use the new buffer pool helpers. (`pkg/spooledtempfile/spooled_test.go`) [[1]](diffhunk://#diff-4be7432a09fe448ab776901af2e2896827473d73bf713efc5a5a1658b1850e9dL506-R506) [[2]](diffhunk://#diff-4be7432a09fe448ab776901af2e2896827473d73bf713efc5a5a1658b1850e9dL562-R562)

**Benchmarking:**

* Added a new benchmark suite to `spooled_bench_test.go` covering in-memory, spill-to-disk, full-on-disk, high-memory-signal, parallel, and hash-read scenarios, providing extensive performance coverage. (`pkg/spooledtempfile/spooled_bench_test.go`)

These changes make the package more robust in containerized environments, improve buffer reuse safety (fixes SA6002 warnings), and provide tools for performance analysis.

Before pool buffer changes:
```
goos: darwin
goarch: arm64
pkg: github.com/internetarchive/gowarc/pkg/spooledtempfile
cpu: Apple M4
BenchmarkWrite_InMemory_Small-10                   10932            108007 ns/op        2427.10 MB/s     1095746 B/op        114 allocs/op
BenchmarkWrite_SpillToDisk-10                        580           1802795 ns/op        2326.56 MB/s     4786692 B/op        146 allocs/op
BenchmarkWrite_FullOnDisk-10                         831           1388372 ns/op        3021.02 MB/s        1225 B/op         23 allocs/op
BenchmarkWrite_SpillDueToHighMemSignal-10           5242            301173 ns/op         870.41 MB/s         585 B/op         10 allocs/op
BenchmarkRead_AfterWrite_InMemory-10              157347              7584 ns/op        34567.33 MB/s          0 B/op          0 allocs/op
BenchmarkRead_AfterWrite_OnDisk-10                  5414            208808 ns/op        40173.76 MB/s          0 B/op          0 allocs/op
BenchmarkReadAt_OnDisk-10                         605002              1954 ns/op        33534.04 MB/s          0 B/op          0 allocs/op
BenchmarkParallel_CreateAndWrite_512KB-10           3662            299933 ns/op        1748.02 MB/s     4421662 B/op        235 allocs/op
BenchmarkRead_Hash_OnDisk-10                          86          11994375 ns/op        2797.51 MB/s         160 B/op          2 allocs/op
BenchmarkCreateClose_NoWrite-10                 32111533                35.94 ns/op          120 B/op          2 allocs/op
PASS
ok      github.com/internetarchive/gowarc/pkg/spooledtempfile   13.083s
```

After pool buffer changes:

```
goos: darwin
goarch: arm64
pkg: github.com/internetarchive/gowarc/pkg/spooledtempfile
cpu: Apple M4
BenchmarkWrite_InMemory_Small-10                   10814            108188 ns/op        2423.05 MB/s     1095474 B/op        114 allocs/op
BenchmarkWrite_SpillToDisk-10                        885           1414374 ns/op        2965.48 MB/s     4786899 B/op        146 allocs/op
BenchmarkWrite_FullOnDisk-10                         963           1253683 ns/op        3345.59 MB/s        1283 B/op         23 allocs/op
BenchmarkWrite_SpillDueToHighMemSignal-10           6628            184917 ns/op        1417.63 MB/s         604 B/op         10 allocs/op
BenchmarkRead_AfterWrite_InMemory-10              154537              7254 ns/op        36138.70 MB/s          0 B/op          0 allocs/op
BenchmarkRead_AfterWrite_OnDisk-10                  5253            213364 ns/op        39315.95 MB/s          0 B/op          0 allocs/op
BenchmarkReadAt_OnDisk-10                         473926              2205 ns/op        29715.52 MB/s          0 B/op          0 allocs/op
BenchmarkParallel_CreateAndWrite_512KB-10           3932            302094 ns/op        1735.51 MB/s     4421353 B/op        235 allocs/op
BenchmarkRead_Hash_OnDisk-10                          86          12157159 ns/op        2760.06 MB/s         160 B/op          2 allocs/op
BenchmarkCreateClose_NoWrite-10                 32153550                36.02 ns/op          120 B/op          2 allocs/op
PASS
ok      github.com/internetarchive/gowarc/pkg/spooledtempfile   12.794s
```