### PR TITLE
Add standard_gzip build tag to use standard Go gzip package

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ func main() {
 }
 ```
 
+## Build tags
+
+- `standard_gzip`: Use the standard library gzip implementation instead of the faster one from [klauspost](https://github.com/klauspost/compress)
+- `klauspost_gzip`: Use the faster gzip implementation from [klauspost](https://github.com/klauspost/compress) (default, you don't need to specify it)
+
 ## License
 
 This module is released under CC0 license.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/internetarchive/gowarc
 go 1.24.2
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.18.0
 	github.com/maypok86/otter v1.2.4
@@ -18,6 +17,12 @@ require (
 	golang.org/x/net v0.39.0
 	golang.org/x/sync v0.13.0
 )
+
+// By default, and historically, this project uses klauspost's gzip implementation,
+// which is faster than the standard library gzip, but comes at the cost of less predictable
+// memory usage. It's widely used and stable but if you want to use the standard library gzip,
+// you can build with the standard_gzip tag:
+// go build -tags standard_gzip
 
 require (
 	github.com/andybalholm/brotli v1.1.1 // indirect

--- a/gzip_interface.go
+++ b/gzip_interface.go
@@ -1,0 +1,22 @@
+package warc
+
+import (
+	"io"
+)
+
+// GzipWriterInterface defines the interface for gzip writers
+// This allows us to switch between standard gzip and klauspost gzip
+// based on build tags
+type GzipWriterInterface interface {
+	io.WriteCloser
+	Flush() error
+}
+
+// GzipReaderInterface defines the interface for gzip readers
+// This allows us to switch between standard gzip and klauspost gzip
+// based on build tags
+type GzipReaderInterface interface {
+	io.ReadCloser
+	Multistream(enable bool)
+	Reset(r io.Reader) error
+}

--- a/gzip_klauspost_impl.go
+++ b/gzip_klauspost_impl.go
@@ -1,0 +1,31 @@
+//go:build !standard_gzip || klauspost_gzip
+// +build !standard_gzip klauspost_gzip
+
+package warc
+
+import (
+	"io"
+
+	gzip "github.com/klauspost/compress/gzip"
+)
+
+func newGzipWriter(w io.Writer) GzipWriterInterface {
+	return gzip.NewWriter(w)
+}
+
+// klauspostGzipReader wraps the klauspost gzip.Reader
+type klauspostGzipReader struct {
+	*gzip.Reader
+}
+
+func (r *klauspostGzipReader) Multistream(enable bool) {
+	r.Reader.Multistream(enable)
+}
+
+func newGzipReader(reader io.Reader) (GzipReaderInterface, error) {
+	r, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	return &klauspostGzipReader{r}, nil
+}

--- a/gzip_standard_impl.go
+++ b/gzip_standard_impl.go
@@ -6,7 +6,6 @@ package warc
 import (
 	"compress/gzip"
 	"io"
-	"log/slog"
 )
 
 func newGzipWriter(w io.Writer) GzipWriterInterface {

--- a/gzip_standard_impl.go
+++ b/gzip_standard_impl.go
@@ -1,0 +1,31 @@
+//go:build standard_gzip
+// +build standard_gzip
+
+package warc
+
+import (
+	"compress/gzip"
+	"io"
+	"log/slog"
+)
+
+func newGzipWriter(w io.Writer) GzipWriterInterface {
+	return gzip.NewWriter(w)
+}
+
+// standardGzipReader wraps the standard library gzip.Reader
+type standardGzipReader struct {
+	*gzip.Reader
+}
+
+func (r *standardGzipReader) Multistream(enable bool) {
+	r.Reader.Multistream(enable)
+}
+
+func newGzipReader(reader io.Reader) (GzipReaderInterface, error) {
+	r, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	return &standardGzipReader{r}, nil
+}

--- a/utils.go
+++ b/utils.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/internetarchive/gowarc/pkg/spooledtempfile"
-	gzip "github.com/klauspost/compress/gzip"
-
 	"github.com/klauspost/compress/zstd"
 )
 
@@ -46,7 +44,7 @@ func NewWriter(writer io.Writer, fileName string, digestAlgorithm DigestAlgorith
 	if compression != "" {
 		switch compression {
 		case "GZIP":
-			gzipWriter := gzip.NewWriter(writer)
+			gzipWriter := newGzipWriter(writer)
 
 			return &Writer{
 				FileName:        fileName,

--- a/write.go
+++ b/write.go
@@ -13,8 +13,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-//go:generate go build -tags standard_gzip
-
 // Writer writes WARC records to WARC files.
 type Writer struct {
 	GZIPWriter      GzipWriterInterface

--- a/write.go
+++ b/write.go
@@ -9,15 +9,15 @@ import (
 	"time"
 
 	"github.com/internetarchive/gowarc/pkg/spooledtempfile"
-	"github.com/klauspost/compress/gzip"
-
 	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
 )
 
+//go:generate go build -tags standard_gzip
+
 // Writer writes WARC records to WARC files.
 type Writer struct {
-	GZIPWriter      *gzip.Writer
+	GZIPWriter      GzipWriterInterface
 	ZSTDWriter      *zstd.Encoder
 	FileWriter      *bufio.Writer
 	FileName        string


### PR DESCRIPTION
This pull request introduces an abstraction layer to support both the standard library and klauspost gzip implementations, allowing users to select the gzip backend via build tags. The changes refactor the codebase to use interface-based gzip readers and writers, making the implementation backend-agnostic. Documentation and build instructions are also updated to clarify the new options.

**Gzip backend abstraction and implementation:**

* Added `GzipWriterInterface` and `GzipReaderInterface` interfaces in `gzip_interface.go` to abstract gzip operations and enable switching implementations via build tags.
* Implemented klauspost gzip backend in `gzip_klauspost_impl.go` (default) and standard library gzip backend in `gzip_standard_impl.go` (selectable with `standard_gzip` build tag). [[1]](diffhunk://#diff-76ab0ceee01870430789e6caecc16e27b12f1c73178d315f9b4204c32b8b31feR1-R31) [[2]](diffhunk://#diff-223a44591ac6119c7836f455e928c8961ad70f19d10b323aad817e40b12bff9dR1-R31)

**Codebase refactoring for backend-agnostic gzip:**

* Replaced direct usage of `github.com/klauspost/compress/gzip` types with the new interfaces in `read.go`, `utils.go`, and `write.go`, updating relevant struct fields and logic to use the interface-based approach. [[1]](diffhunk://#diff-2afeb2e02182ad5bb61e988b290013cdc0e5dd12981568a89dec415caafab361L7-L18) [[2]](diffhunk://#diff-2afeb2e02182ad5bb61e988b290013cdc0e5dd12981568a89dec415caafab361L40-R37) [[3]](diffhunk://#diff-2afeb2e02182ad5bb61e988b290013cdc0e5dd12981568a89dec415caafab361L240-R237) [[4]](diffhunk://#diff-2afeb2e02182ad5bb61e988b290013cdc0e5dd12981568a89dec415caafab361L441-R438) [[5]](diffhunk://#diff-8b7f25bac2ae04c2ce2abb628c6aa28103fd113103a62f3e9d232fa995684915L14-L15) [[6]](diffhunk://#diff-8b7f25bac2ae04c2ce2abb628c6aa28103fd113103a62f3e9d232fa995684915L49-R47) [[7]](diffhunk://#diff-0965f1fa88ac40fcfc62a7eb27c953cf287c8d9a10e80f5d6e84aeb165322594L12-R20)

**Documentation and build instructions:**

* Updated `README.md` and `go.mod` with clear documentation on the available build tags (`standard_gzip`, `klauspost_gzip`), default behavior, and tradeoffs between implementations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116-R120) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R21-R26)

**Dependency cleanup:**

* Removed unused `github.com/davecgh/go-spew` dependency from `go.mod`.